### PR TITLE
feat: add responsive sticky header component

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,95 @@
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: saturate(180%) blur(5px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.75rem 1rem;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  text-decoration: none;
+  color: #000;
+}
+
+.menu-button {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link {
+  position: relative;
+  padding: 0.5rem 0;
+  text-decoration: none;
+  color: #000;
+  transition: color 0.2s ease;
+}
+
+.nav-link:hover {
+  color: #dd7c5e;
+}
+
+.nav-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background-color: #dd7c5e;
+  transition: width 0.3s ease;
+}
+
+.nav-link:hover::after,
+.nav-link.active::after {
+  width: 100%;
+}
+
+.nav-link.active {
+  color: #dd7c5e;
+}
+
+@media (max-width: 768px) {
+  .menu-button {
+    display: block;
+  }
+
+  .nav-list {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background-color: rgba(255, 255, 255, 0.95);
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 1rem;
+    gap: 1rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transform: translateY(-200%);
+    transition: transform 0.3s ease;
+  }
+
+  .nav-list.nav-list--open {
+    transform: translateY(0);
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import { Menu, X } from "lucide-react";
+import "./Header.css";
+
+interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+}
+
+const navItems: NavItem[] = [
+  { id: "home", label: "Home", href: "#home" },
+  { id: "subscriptions", label: "Subscriptions", href: "#subscriptions" },
+  { id: "about", label: "About", href: "#about" },
+  { id: "contact", label: "Contact", href: "#contact" },
+];
+
+export const Header = (): JSX.Element => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [active, setActive] = useState("home");
+
+  const toggleMenu = () => setMenuOpen((prev) => !prev);
+
+  const handleNavClick = (id: string) => {
+    setActive(id);
+    setMenuOpen(false);
+  };
+
+  return (
+    <header className="header" role="banner">
+      <nav className="nav" aria-label="Main Navigation">
+        <a href="#home" className="logo" aria-label="Infoverse home">
+          Infoverse
+        </a>
+
+        <button
+          className="menu-button"
+          aria-label="Toggle navigation menu"
+          aria-expanded={menuOpen}
+          onClick={toggleMenu}
+        >
+          {menuOpen ? <X size={24} /> : <Menu size={24} />}
+        </button>
+
+        <ul className={`nav-list ${menuOpen ? "nav-list--open" : ""}`}>
+          {navItems.map((item) => (
+            <li key={item.id}>
+              <a
+                href={item.href}
+                className={`nav-link ${active === item.id ? "active" : ""}`}
+                onClick={() => handleNavClick(item.id)}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </header>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
## Summary
- add new Header component with semantic navigation and mobile menu
- style navbar with sticky position, hover animations and active link highlighting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c026329c1c8326a3f4ea1c5d7faf68