### PR TITLE
feat: add responsive sticky header

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,110 @@
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: #333;
+  text-decoration: none;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.nav-links li {
+  list-style: none;
+}
+
+.nav-link {
+  position: relative;
+  text-decoration: none;
+  color: #333;
+  padding: 0.25rem 0;
+  transition: color 0.2s ease-in-out;
+}
+
+.nav-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 0%;
+  height: 2px;
+  background-color: #33a1cd;
+  transition: width 0.3s ease-in-out;
+}
+
+.nav-link:hover,
+.nav-link:focus {
+  color: #33a1cd;
+}
+
+.nav-link:hover::after,
+.nav-link:focus::after,
+.nav-link.active::after {
+  width: 100%;
+}
+
+.nav-link.active {
+  color: #33a1cd;
+}
+
+.hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.hamburger:focus {
+  outline: 2px solid #33a1cd;
+  outline-offset: 2px;
+}
+
+.bar {
+  width: 24px;
+  height: 2px;
+  background-color: #333;
+  transition: background-color 0.2s ease-in-out;
+}
+
+@media (max-width: 768px) {
+  .nav-links {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background-color: rgba(255, 255, 255, 0.95);
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 1rem;
+    width: 200px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    display: none;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .hamburger {
+    display: flex;
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from "react";
+import "./Header.css";
+
+const Header: React.FC = () => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [active, setActive] = useState("home");
+
+  useEffect(() => {
+    const sections = document.querySelectorAll<HTMLElement>("section[id], header[id]");
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: "-50% 0px -50% 0px" }
+    );
+
+    sections.forEach(section => observer.observe(section));
+    return () => observer.disconnect();
+  }, []);
+
+  const handleLinkClick = (id: string) => {
+    setActive(id);
+    setMenuOpen(false);
+  };
+
+  return (
+    <header className="site-header">
+      <nav className="nav" aria-label="Main navigation">
+        <a href="#home" className="logo">
+          Infoverse
+        </a>
+        <button
+          className="hamburger"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
+          <span className="bar" />
+          <span className="bar" />
+          <span className="bar" />
+        </button>
+        <ul
+          id="primary-navigation"
+          className={`nav-links ${menuOpen ? "open" : ""}`}
+        >
+          <li>
+            <a
+              href="#home"
+              className={`nav-link ${active === "home" ? "active" : ""}`}
+              onClick={() => handleLinkClick("home")}
+            >
+              Home
+            </a>
+          </li>
+          <li>
+            <a
+              href="#subscriptions"
+              className={`nav-link ${active === "subscriptions" ? "active" : ""}`}
+              onClick={() => handleLinkClick("subscriptions")}
+            >
+              Subscriptions
+            </a>
+          </li>
+          <li>
+            <a
+              href="#testimonials"
+              className={`nav-link ${active === "testimonials" ? "active" : ""}`}
+              onClick={() => handleLinkClick("testimonials")}
+            >
+              Testimonials
+            </a>
+          </li>
+          <li>
+            <a
+              href="#contact"
+              className={`nav-link ${active === "contact" ? "active" : ""}`}
+              onClick={() => handleLinkClick("contact")}
+            >
+              Contact
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+};
+
+export default Header;
+

--- a/src/screens/ILandingPage/ILandingPage.tsx
+++ b/src/screens/ILandingPage/ILandingPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
-import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs";
+import Header from "../../components/Header";
 
 const howItWorksSteps = [
   {
@@ -49,54 +49,13 @@ const footerLinks = [
 export const ILandingPage = (): JSX.Element => {
   return (
     <div className="bg-white min-h-screen w-full" data-model-id="160:1713">
+      <Header />
       <div className="max-w-[1920px] mx-auto bg-[#f9f9f9] rounded-[20px] overflow-hidden">
-        {/* Header Section */}
-        <header className="bg-[#33a1cd] rounded-[30px] border border-white p-8 relative overflow-hidden">
-          <div className="translate-y-[-1rem] animate-fade-in opacity-0 [--animation-delay:0ms]">
-            {/* Navigation */}
-            <nav className="flex justify-between items-center mb-8">
-              <div className="flex items-center gap-4">
-                <Tabs
-                  defaultValue="home"
-                  className="bg-[#f9f9f9] rounded-[40px] border border-white shadow-[0px_4px_4px_#00000040]"
-                >
-                  <TabsList className="bg-transparent p-0 h-auto">
-                    <TabsTrigger
-                      value="home"
-                      className="bg-[#33a1cd] text-white border border-white rounded-[40px] px-16 py-8 text-4xl font-normal data-[state=active]:bg-[#33a1cd] data-[state=active]:text-white h-auto"
-                    >
-                      Home
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="subscriptions"
-                      className="bg-transparent text-black px-16 py-8 text-4xl font-normal data-[state=active]:bg-[#33a1cd] data-[state=active]:text-white h-auto"
-                    >
-                      Subscriptions
-                    </TabsTrigger>
-                  </TabsList>
-                </Tabs>
-              </div>
-
-              <div className="bg-[#f9f9f9] rounded-[30px] shadow-[0px_4px_4px_#00000040] px-12 py-4">
-                <div className="flex items-center gap-8">
-                  <Button
-                    variant="ghost"
-                    className="text-black text-4xl font-normal p-0 h-auto hover:bg-transparent"
-                  >
-                    LOG IN
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    className="text-black text-4xl font-normal p-0 h-auto hover:bg-transparent"
-                  >
-                    SIGN UP
-                  </Button>
-                </div>
-              </div>
-            </nav>
-          </div>
-
-          {/* Hero Content */}
+        {/* Hero Section */}
+        <header
+          id="home"
+          className="bg-[#33a1cd] rounded-[30px] border border-white p-8 relative overflow-hidden"
+        >
           <div className="grid lg:grid-cols-2 gap-8 items-center">
             <div className="space-y-6">
               <div className="translate-y-[-1rem] animate-fade-in opacity-0 [--animation-delay:200ms]">
@@ -135,7 +94,7 @@ export const ILandingPage = (): JSX.Element => {
         </header>
 
         {/* How It Works Section */}
-        <section className="py-16 px-8">
+        <section id="subscriptions" className="py-16 px-8">
           <div className="translate-y-[-1rem] animate-fade-in opacity-0 [--animation-delay:200ms]">
             <h2 className="text-center [font-family:'Inter',Helvetica] font-semibold text-black text-[80px] leading-normal mb-16">
               How It Works
@@ -210,7 +169,7 @@ export const ILandingPage = (): JSX.Element => {
         </section>
 
         {/* Testimonials Section */}
-        <section className="py-16 px-8">
+        <section id="testimonials" className="py-16 px-8">
           <div className="translate-y-[-1rem] animate-fade-in opacity-0 [--animation-delay:200ms]">
             <h2 className="text-center [font-family:'Inter',Helvetica] font-semibold text-black text-[80px] leading-normal mb-4">
               What Learners Say
@@ -251,7 +210,7 @@ export const ILandingPage = (): JSX.Element => {
         </section>
 
         {/* Footer */}
-        <footer className="bg-[#33a1cd] rounded-[20px] p-8">
+        <footer id="contact" className="bg-[#33a1cd] rounded-[20px] p-8">
           <div className="flex flex-col lg:flex-row justify-between items-start gap-8">
             <div className="flex items-center gap-4">
               <img


### PR DESCRIPTION
## Summary
- add reusable sticky header with active link highlighting
- style nav with hover animations and responsive hamburger menu
- integrate header into landing page sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c026329c1c8326a3f4ea1c5d7faf68